### PR TITLE
Use logo image in header

### DIFF
--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,5 +1,5 @@
 <header class="site-header" role="navigation" aria-label="Main">
-  <div class="logo"><a class="logo-link" href="/">E•CLIPSION</a></div>
+  <div class="logo"><a class="logo-link" href="/"><img src="/images/brand/Logo_big.png" alt="Eclipsion logo" /></a></div>
   <nav class="main-nav">
     <a href="/">Home</a>
     <a href="/pages/team/">Team</a>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -28,6 +28,7 @@
 .logo a { color: inherit; text-decoration: none; }
 .logo a:hover { filter: brightness(1.08); }
 .logo{font-weight:700; letter-spacing:.06em}
+.logo img{display:block;height:48px;width:auto;}
 .main-nav a{margin-left:24px}
 .main-nav a:hover{text-decoration:underline}
 


### PR DESCRIPTION
## Summary
- replace textual site name with `Logo_big.png` brand image in navigation header
- add CSS rule to scale the 4K logo for consistent header height

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898e2d69d8883249ff4fc26efee07af