### PR TITLE
Use logo image in header

### DIFF
--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,11 +1,13 @@
 <header class="site-header" role="navigation" aria-label="Main">
-  <div class="logo"><a class="logo-link" href="/">E•CLIPSION</a></div>
-  <nav class="main-nav">
-    <a href="/">Home</a>
-    <a href="/pages/team/">Team</a>
-    <a href="/pages/lore-and-fate/">Lore &amp; Fate</a>
-    <a href="/pages/toolkit/">Toolkit</a>
-    <a href="/pages/merch/">Merch</a>
-    <a href="/pages/contact/">Contact</a>
-  </nav>
+  <div class="container">
+    <div class="logo"><a class="logo-link" href="/"><img src="/images/brand/Logo_big.png" alt="Eclipsion logo" /></a></div>
+    <nav class="main-nav">
+      <a href="/">Home</a>
+      <a href="/pages/team/">Team</a>
+      <a href="/pages/lore-and-fate/">Lore &amp; Fate</a>
+      <a href="/pages/toolkit/">Toolkit</a>
+      <a href="/pages/merch/">Merch</a>
+      <a href="/pages/contact/">Contact</a>
+    </nav>
+  </div>
 </header>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,8 +2,11 @@
 
 /* Header-Grundlayout */
 .site-header{
+  padding:18px 0;
+}
+
+.site-header .container{
   display:flex; align-items:center; justify-content:space-between;
-  padding:18px clamp(16px,4vw,48px);
 }
 
 /* Sticky-Verhalten */
@@ -28,6 +31,7 @@
 .logo a { color: inherit; text-decoration: none; }
 .logo a:hover { filter: brightness(1.08); }
 .logo{font-weight:700; letter-spacing:.06em}
+.logo img{display:block;height:clamp(48px,8vw,96px);width:auto;}
 .main-nav a{margin-left:24px}
 .main-nav a:hover{text-decoration:underline}
 


### PR DESCRIPTION
## Summary
- limit header width with a `.container` wrapper so the navigation matches body width
- resize the brand logo responsively via `clamp()` and shift flex layout to the inner container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898e2d69d8883249ff4fc26efee07af