### PR TITLE
Make navigation bar sticky

### DIFF
--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,4 +1,4 @@
-<header class="site-header" role="navigation" aria-label="Main">
+<header class="site-header sticky-ready" role="navigation" aria-label="Main">
   <div class="container">
     <div class="logo"><a class="logo-link" href="/"><img src="/images/brand/Logo_big.png" alt="Eclipsion logo" /></a></div>
     <nav class="main-nav">

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -15,8 +15,7 @@ export function enableStickyHeader() {
   const header = document.querySelector<HTMLElement>('.site-header');
   if (!header) return;
 
-  // CSS-Hook
-  header.classList.add('sticky-ready');
+  // Header carries sticky-ready class in markup; we only need to detect when it sticks
 
   // Sentinel vor den Header setzen, um "Ankleben" zu erkennen
   const sentinel = document.createElement('div');


### PR DESCRIPTION
## Summary
- Ensure header navigation uses sticky positioning immediately by default
- Simplify sticky header helper to only track when header is stuck

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898efcb8b0083249b50bc780a3d5e42