### PR TITLE
fix: keep navigation bar sticky

### DIFF
--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -2,7 +2,9 @@ async function inject(selector: string, url: string) {
   const host = document.querySelector<HTMLElement>(selector);
   if (!host) return;
   const res = await fetch(url, { cache: 'no-store' });
-  host.innerHTML = await res.text();
+  // Replace the placeholder node entirely so sticky positioning
+  // on injected fragments isn't limited by the temporary wrapper
+  host.outerHTML = await res.text();
 }
 
 export async function mountLayout() {
@@ -10,13 +12,10 @@ export async function mountLayout() {
   await inject('#site-footer', '/partials/footer.html');
 }
 
-/** Macht .site-header sticky und fügt 'is-stuck' hinzu, sobald sie oben klebt */
+/** Überwacht .site-header und fügt 'is-stuck' hinzu, sobald sie oben klebt */
 export function enableStickyHeader() {
   const header = document.querySelector<HTMLElement>('.site-header');
   if (!header) return;
-
-  // CSS-Hook
-  header.classList.add('sticky-ready');
 
   // Sentinel vor den Header setzen, um "Ankleben" zu erkennen
   const sentinel = document.createElement('div');

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,16 +1,8 @@
 /* Header + Hero */
 
-/* Header-Grundlayout */
+/* Header-Grundlayout + sticky Verhalten */
 .site-header{
   padding:18px 0;
-}
-
-.site-header .container{
-  display:flex; align-items:center; justify-content:space-between;
-}
-
-/* Sticky-Verhalten */
-.sticky-ready {
   position: sticky;
   top: 0;
   z-index: 100; /* über Content */
@@ -20,8 +12,12 @@
   transition: background-color .2s ease, box-shadow .2s ease, border-color .2s ease;
 }
 
+.site-header .container{
+  display:flex; align-items:center; justify-content:space-between;
+}
+
 /* Sobald der Header oben "klebt" (Klasse via JS) etwas deckender + Schatten */
-.sticky-ready.is-stuck{
+.site-header.is-stuck{
   background: rgba(11, 9, 17, 0.92);
   box-shadow: 0 10px 30px rgba(0,0,0,.35);
   border-bottom-color: rgba(255,255,255,.08);


### PR DESCRIPTION
## Summary
- replace placeholder injection with direct header markup so sticky positioning isn't constrained by a wrapper
- ensure the navigation header remains fixed at the top once scrolled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f22f74308324ac11286c1d5c4f04