### PR TITLE
feat: add cards layout to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,60 +19,54 @@
   </section>
 
   <!-- Header/Navi STARTET direkt unter dem Hero und wird sticky -->
-  <div id="site-header"></div>
+    <div id="site-header"></div>
 
-    <main class="landing-container">
+      <main>
+        <section class="layout cards">
 
-      <!-- Reihe 1 -->
-      <section class="landing-row" style="--landing-image-h: 460px">
-        <article class="landingCard landingCard--text">
-          <h2>Get to know us</h2>
-          <p>Text "Team"</p>
-        </article>
+          <!-- Vollbreit: Text links, Bild rechts (nahtlos aneinander) -->
+          <div class="media-row">
+            <div class="panel text">
+              <h3>Get to know us</h3>
+              <p>Erfahre mehr über unser Team und unsere Mission.</p>
+            </div>
+            <div class="panel image">
+              <img src="/public/images/teamfoto.jpg" alt="Teamfoto">
+            </div>
+          </div>
 
-        <a class="landingCard landingCard--image" href="/pages/team/">
-          <img src="https://placehold.co/600x460?text=Team" alt="Teamfoto">
-        </a>
-      </section>
+          <!-- Halbe Breite: Bild + Caption -->
+          <figure class="tile figure">
+            <img src="/public/images/lore-and-fate.jpg" alt="Lore &amp; Fate">
+            <figcaption>
+              <h4>Lore &amp; Fate</h4>
+              <p>Entdecke die Welt und Geschichte von Lore &amp; Fate.</p>
+            </figcaption>
+          </figure>
 
-      <!-- Reihe 2 -->
-      <section class="landing-row landing-row--swap" style="--landing-image-h: 320px">
-        <div class="landing-stack">
-          <a class="landingCard landingCard--image" href="/pages/lore-and-fate/">
-            <img src="https://placehold.co/600x320?text=Lore+%26+Fate" alt="Lore &amp; Fate">
-          </a>
-          <article class="landingCard landingCard--text landingCard--text-auto">
-            <h3>Lore &amp; Fate</h3>
-            <p>Text "Lore &amp; Fate"</p>
-          </article>
-        </div>
+          <figure class="tile figure">
+            <img src="/public/images/toolkit.jpg" alt="Toolkit">
+            <figcaption>
+              <h4>Toolkit</h4>
+              <p>Unser Toolkit für kreative Abenteuer.</p>
+            </figcaption>
+          </figure>
 
-        <div class="landing-stack">
-          <a class="landingCard landingCard--image" href="/pages/toolkit/">
-            <img src="https://placehold.co/600x320?text=Toolkit" alt="Toolkit">
-          </a>
-          <article class="landingCard landingCard--text landingCard--text-auto">
-            <h3>Toolkit</h3>
-            <p>Text "Toolkit"</p>
-          </article>
-        </div>
-      </section>
+          <!-- Vollbreit: Bild links, Text rechts -->
+          <div class="media-row reverse">
+            <div class="panel image">
+              <img src="/public/images/merch.jpg" alt="Merch Foto">
+            </div>
+            <div class="panel text">
+              <h3>Merch</h3>
+              <p>Exklusive Fanartikel für dich.</p>
+            </div>
+          </div>
 
-      <!-- Reihe 3 -->
-      <section class="landing-row" style="--landing-image-h: 380px">
-        <a class="landingCard landingCard--image" href="/pages/merch/">
-          <img src="https://placehold.co/600x380?text=Merch" alt="Merch Foto">
-        </a>
+        </section>
+      </main>
 
-        <article class="landingCard landingCard--text">
-          <h2>Merch</h2>
-          <p>Text "Merch"</p>
-        </article>
-      </section>
-
-    </main>
-
-  <div id="site-footer"></div>
-  <script type="module" src="/src/pages/home.ts"></script>
-</body>
-</html>
+    <div id="site-footer"></div>
+    <script type="module" src="/src/pages/home.ts"></script>
+  </body>
+  </html>

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -3,6 +3,7 @@ import { initParallax } from '../lib/parallax';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';
+import '../styles/cards.css';
 
 (async () => {
   await mountLayout();

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,0 +1,94 @@
+/* Container: 2-Spalten-Grid für die Kacheln */
+.layout.cards{
+  --gap: clamp(16px, 3vw, 28px);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--gap);
+  align-items: start;
+  grid-auto-flow: dense;
+}
+
+/* Vollbreite-Reihe: Text & Bild sind zwei separaten Felder ohne sichtbare Fuge */
+.cards .media-row{
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr 1fr; /* Text | Bild */
+  gap: 0;                         /* kein Zwischenraum */
+  align-items: center;            /* Mittelpunkte ausrichten */
+  position: relative;             /* für gemeinsamen Shadow */
+}
+
+/* Gemeinsamer Schatten über die ganze Reihe (verhindert „Naht“-Schatten) */
+.cards .media-row::before{
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(0,0,0,.12);
+  pointer-events: none;
+}
+
+/* Panels: eigene Hintergründe, aber ohne individuellen Shadow */
+.cards .panel{
+  background: #fff7e0;
+  overflow: hidden;
+  padding: clamp(12px, 1.5vw, 20px);
+  border-radius: 12px;
+  box-shadow: none;
+}
+
+/* Text-Panel: außen rund, innen (zum Bild) kantig */
+.cards .media-row .panel.text{
+  display: flex;
+  flex-direction: column;
+  gap: .6rem;
+  border-radius: 12px 0 0 12px; /* links rund, rechts eckig */
+}
+.cards .media-row.reverse .panel.text{
+  border-radius: 0 12px 12px 0; /* rechts rund, links eckig */
+}
+
+/* Bild-Panel mit Innenpadding */
+.cards .panel.image{ padding: clamp(10px, 1vw, 16px); }
+.cards .panel.image img{
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  display: block;
+  /* Bildrundung nur an den äußeren Ecken, passend zum Panel */
+  border-radius: 0 8px 8px 0;
+}
+.cards .media-row.reverse .panel.image img{
+  border-radius: 8px 0 0 8px;
+}
+
+/* Halbe-Breite-Kacheln (Bild + Text darunter) */
+.cards .tile{
+  background: #fff7e0;
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(0,0,0,.12);
+  overflow: hidden;
+  padding: clamp(12px, 1.5vw, 20px);
+}
+.cards .figure{
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+}
+.cards .figure img{
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border-radius: 8px;
+}
+.cards .figure figcaption h4{ margin: 0 0 .25rem; }
+.cards .figure figcaption p{ margin: 0; }
+
+/* Responsive: alles einspaltig, runde Ecken wieder überall */
+@media (max-width: 900px){
+  .layout.cards{ grid-template-columns: 1fr; }
+  .cards .media-row{ grid-template-columns: 1fr; }
+  .cards .panel{ border-radius: 12px; }
+  .cards .panel.image img{ border-radius: 8px; }
+}
+


### PR DESCRIPTION
## Summary
- replace landing rows with new card layout on the homepage
- add card-specific styles and import them in home.ts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c2157f408324bb477b4d099d6b88