### PR TITLE
Constrain card layout to page width

### DIFF
--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -6,6 +6,9 @@
   gap: var(--gap);
   align-items: start;
   grid-auto-flow: dense;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 clamp(16px, 4vw, 48px);
 }
 
 /* Vollbreite-Reihe: Text & Bild sind zwei separaten Felder ohne sichtbare Fuge */


### PR DESCRIPTION
## Summary
- Restrict card layout container to a maximum width and center it with auto margins.
- Add responsive horizontal padding so cards honor the site’s max width.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c3f24d808324b573d790e4d20471