### PR TITLE
refactor: centralize page bootstrap and auto entry detection

### DIFF
--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,10 +1,25 @@
+const fragmentCache = new Map<string, string>();
+
+async function fetchFragment(url: string) {
+  const cached = fragmentCache.get(url) || sessionStorage.getItem(url);
+  if (cached) {
+    fragmentCache.set(url, cached);
+    return cached;
+  }
+  const res = await fetch(url, { cache: 'no-store' });
+  const html = await res.text();
+  fragmentCache.set(url, html);
+  sessionStorage.setItem(url, html);
+  return html;
+}
+
 async function inject(selector: string, url: string) {
   const host = document.querySelector<HTMLElement>(selector);
   if (!host) return;
-  const res = await fetch(url, { cache: 'no-store' });
+  const html = await fetchFragment(url);
   // Replace the placeholder node entirely so sticky positioning
   // on injected fragments isn't limited by the temporary wrapper
-  host.outerHTML = await res.text();
+  host.outerHTML = html;
 }
 
 export async function mountLayout() {

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -1,0 +1,17 @@
+import { mountLayout, enableStickyHeader } from './layout';
+import '../styles/base.css';
+import '../styles/layout.css';
+import '../styles/components.css';
+
+export async function bootstrapPage(options: { parallax?: boolean } = {}) {
+  await mountLayout();
+  enableStickyHeader();
+  if (options.parallax) {
+    const { initParallax } = await import('./parallax');
+    initParallax({
+      heroSelector: '.hero',
+      maxShiftPx: 140,
+      maxScale: 1.10
+    });
+  }
+}

--- a/src/pages/contact.ts
+++ b/src/pages/contact.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/cookie-settings.ts
+++ b/src/pages/cookie-settings.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -1,16 +1,4 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import { initParallax } from '../lib/parallax';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 import '../styles/cards.css';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();  // <— sticky Navi aktiv
-  initParallax({
-    heroSelector: '.hero',
-    maxShiftPx: 140,
-    maxScale: 1.10
-  });
-})();
+bootstrapPage({ parallax: true });

--- a/src/pages/impressum.ts
+++ b/src/pages/impressum.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/imprint.ts
+++ b/src/pages/imprint.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/lore-and-fate.ts
+++ b/src/pages/lore-and-fate.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/merch.ts
+++ b/src/pages/merch.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/privacy-policy.ts
+++ b/src/pages/privacy-policy.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/team.ts
+++ b/src/pages/team.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/src/pages/toolkit.ts
+++ b/src/pages/toolkit.ts
@@ -1,9 +1,3 @@
-import { mountLayout, enableStickyHeader } from '../lib/layout';
-import '../styles/base.css';
-import '../styles/layout.css';
-import '../styles/components.css';
+import { bootstrapPage } from '../lib/page';
 
-(async () => {
-  await mountLayout();
-  enableStickyHeader();
-})();
+bootstrapPage();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,34 @@
 import { defineConfig } from 'vite';
-import { resolve } from 'path';
+import { resolve, join, relative } from 'path';
+import { readdirSync } from 'fs';
+
+function getHtmlEntries() {
+  const entries: Record<string, string> = {
+    home: resolve(__dirname, 'index.html')
+  };
+  const pagesRoot = join(__dirname, 'pages');
+
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && entry.name === 'index.html') {
+        const segments = relative(pagesRoot, fullPath).split('/');
+        const key = segments[segments.length - 2];
+        entries[key] = fullPath;
+      }
+    }
+  }
+
+  walk(pagesRoot);
+  return entries;
+}
 
 export default defineConfig({
   build: {
     rollupOptions: {
-      input: {
-        home: resolve(__dirname, 'index.html'),
-        team: resolve(__dirname, 'pages/team/index.html'),
-        lore: resolve(__dirname, 'pages/lore-and-fate/index.html'),
-        toolkit: resolve(__dirname, 'pages/toolkit/index.html'),
-        merch: resolve(__dirname, 'pages/merch/index.html'),
-        contact: resolve(__dirname, 'pages/contact/index.html'),
-        imprint: resolve(__dirname, 'pages/legal/imprint/index.html'),
-        impressum: resolve(__dirname, 'pages/legal/impressum/index.html'),
-        privacy: resolve(__dirname, 'pages/legal/privacy-policy/index.html'),
-        cookies: resolve(__dirname, 'pages/legal/cookie-settings/index.html')
-      }
+      input: getHtmlEntries()
     }
   }
 });


### PR DESCRIPTION
## Summary
- centralize page setup in a shared bootstrap helper with optional parallax
- cache layout fragments and refactor parallax into a class
- auto-discover HTML entry points in vite config

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899c58ddcbc8324943138996eb72923