### PR TITLE
Adopt BEM naming for landing card styles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## CSS Naming
+
+This project uses the [BEM methodology](https://en.bem.info/methodology/). Use the following pattern for CSS class names:
+
+```
+block-name__element-name--modifier-name
+```
+
+- **Blocks** and **elements** are lowercase and use hyphens for word separation.
+- **Elements** are prefixed with `__` and **modifiers** with `--`.
+- Example: `landing-card__text--auto`.
+
+Please apply these guidelines to all new or refactored styles.

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -165,27 +165,27 @@
   flex-direction: row-reverse;
 }
 
-.landingCard{
+.landing-card{
   border-radius: var(--landing-radius);
   box-shadow: var(--landing-shadow);
   overflow: hidden;
   flex: 1 1 0;
 }
 
-.landingCard--image{
+.landing-card__image{
   background: #0f0d1c;
   border: 4px solid var(--landing-ink);
   block-size: var(--landing-image-h);
   display: grid;
 }
-.landingCard--image img{
+.landing-card__image img{
   inline-size: 100%;
   block-size: 100%;
   object-fit: cover;
   display: block;
 }
 
-.landingCard--text{
+.landing-card__text{
   background: var(--landing-paper);
   border: 4px solid var(--landing-paper);
   block-size: calc(var(--landing-image-h) * 0.75);
@@ -196,7 +196,7 @@
   gap: .5rem;
 }
 
-.landingCard--text-auto{
+.landing-card__text--auto{
   block-size: auto;
   align-self: start;
 }
@@ -210,6 +210,6 @@
 
 @media (max-width: 900px){
   .landing-row{ flex-direction: column; }
-  .landingCard--image,
-  .landingCard--text{ block-size: auto; }
+  .landing-card__image,
+  .landing-card__text{ block-size: auto; }
 }


### PR DESCRIPTION
## Summary
- Rename landing card CSS classes to follow BEM conventions
- Document CSS naming guidelines in a new CONTRIBUTING guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c99f20f48324acf424c4a7202d11