### PR TITLE
chore: add stylelint configuration

### DIFF
--- a/.github/workflows/VireAction.yaml
+++ b/.github/workflows/VireAction.yaml
@@ -37,6 +37,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Lint CSS
+        run: npm run lint:css
       - name: Build
         run: npm run build
       - name: Setup Pages

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,10 @@
+{
+  "extends": "stylelint-config-standard",
+  "plugins": ["stylelint-order"],
+  "rules": {
+    "order/properties-alphabetical-order": true,
+    "indentation": 2,
+    "color-hex-case": "lower",
+    "max-empty-lines": 1
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,10 +7,14 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests specified\""
+    "test": "echo \"No tests specified\"",
+    "lint:css": "stylelint \"src/**/*.css\""
   },
   "devDependencies": {
     "vite": "^5.2.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "stylelint": "^16.8.1",
+    "stylelint-config-standard": "^36.0.0",
+    "stylelint-order": "^6.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- add stylelint standard config and rules for property ordering and formatting
- add `lint:css` npm script
- run CSS lint in GitHub Actions workflow

## Testing
- `npm test`
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c9a0c5508324a2d9bc9a2cb6688f