### PR TITLE
feat: centralize style variables

### DIFF
--- a/src/pages/contact.ts
+++ b/src/pages/contact.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/cookie-settings.ts
+++ b/src/pages/cookie-settings.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -1,5 +1,6 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
 import { initParallax } from '../lib/parallax';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/impressum.ts
+++ b/src/pages/impressum.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/imprint.ts
+++ b/src/pages/imprint.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/lore-and-fate.ts
+++ b/src/pages/lore-and-fate.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/merch.ts
+++ b/src/pages/merch.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/privacy-policy.ts
+++ b/src/pages/privacy-policy.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/team.ts
+++ b/src/pages/team.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/pages/toolkit.ts
+++ b/src/pages/toolkit.ts
@@ -1,4 +1,5 @@
 import { mountLayout, enableStickyHeader } from '../lib/layout';
+import '../styles/variables.css';
 import '../styles/base.css';
 import '../styles/layout.css';
 import '../styles/components.css';

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,17 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&display=swap');
 
-:root{
-  --bg-top-1:#5a2bc4;
-  --bg-top-2:#c24bb8;
-  --bg-top-3:#ff8a00;
-  --bg-top-4:#ffd36b;
-  --fg-silhouette:#120a0f;
-  --card-cream:#f9efc8;
-  --ink:#1b1633;
-  --text:#f7f3e8;
-  --muted:#cbbf99;
-}
-
 *{box-sizing:border-box}
 html{scroll-behavior:smooth}
 body{
@@ -25,4 +13,4 @@ a{color:var(--text);text-decoration:none;outline-offset:3px}
 a:focus-visible{outline:2px solid var(--bg-top-4)}
 .container{max-width:1200px;margin:0 auto;padding:0 clamp(16px,4vw,48px)}
 .shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
-.round{border-radius:16px}
+.round{border-radius:var(--radius-lg)}

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -26,17 +26,17 @@
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   box-shadow: 0 6px 18px rgba(0,0,0,.12);
   pointer-events: none;
 }
 
 /* Panels: eigene Hintergründe, aber ohne individuellen Shadow */
 .cards .panel{
-  background: #fff7e0;
+  background: var(--color-card);
   overflow: hidden;
-  padding: clamp(12px, 1.5vw, 20px);
-  border-radius: 12px;
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
   box-shadow: none;
 }
 
@@ -45,10 +45,10 @@
   display: flex;
   flex-direction: column;
   gap: .6rem;
-  border-radius: 12px 0 0 12px; /* links rund, rechts eckig */
+  border-radius: var(--radius-md) 0 0 var(--radius-md); /* links rund, rechts eckig */
 }
 .cards .media-row.reverse .panel.text{
-  border-radius: 0 12px 12px 0; /* rechts rund, links eckig */
+  border-radius: 0 var(--radius-md) var(--radius-md) 0; /* rechts rund, links eckig */
 }
 
 /* Bild-Panel mit Innenpadding */
@@ -59,19 +59,19 @@
   object-fit: cover;
   display: block;
   /* Bildrundung nur an den äußeren Ecken, passend zum Panel */
-  border-radius: 0 8px 8px 0;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 .cards .media-row.reverse .panel.image img{
-  border-radius: 8px 0 0 8px;
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
 }
 
 /* Halbe-Breite-Kacheln (Bild + Text darunter) */
 .cards .tile{
-  background: #fff7e0;
-  border-radius: 12px;
+  background: var(--color-card);
+  border-radius: var(--radius-md);
   box-shadow: 0 6px 18px rgba(0,0,0,.12);
   overflow: hidden;
-  padding: clamp(12px, 1.5vw, 20px);
+  padding: var(--space-sm);
 }
 .cards .figure{
   display: flex;
@@ -82,7 +82,7 @@
   width: 100%;
   aspect-ratio: 16 / 10;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
 }
 .cards .figure figcaption h4{ margin: 0 0 .25rem; }
 .cards .figure figcaption p{ margin: 0; }
@@ -91,7 +91,7 @@
 @media (max-width: 900px){
   .layout.cards{ grid-template-columns: 1fr; }
   .cards .media-row{ grid-template-columns: 1fr; }
-  .cards .panel{ border-radius: 12px; }
-  .cards .panel.image img{ border-radius: 8px; }
+  .cards .panel{ border-radius: var(--radius-md); }
+  .cards .panel.image img{ border-radius: var(--radius-sm); }
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -173,7 +173,7 @@
 }
 
 .landingCard--image{
-  background: #0f0d1c;
+  background: var(--color-dark);
   border: 4px solid var(--landing-ink);
   block-size: var(--landing-image-h);
   display: grid;
@@ -203,7 +203,7 @@
 
 .landing-stack{
   display: grid;
-  gap: clamp(12px, 1.5vw, 20px);
+  gap: var(--space-sm);
   flex: 1 1 0;
   min-inline-size: 0;
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,0 +1,17 @@
+:root{
+  --bg-top-1:#5a2bc4;
+  --bg-top-2:#c24bb8;
+  --bg-top-3:#ff8a00;
+  --bg-top-4:#ffd36b;
+  --fg-silhouette:#120a0f;
+  --card-cream:#f9efc8;
+  --ink:#1b1633;
+  --text:#f7f3e8;
+  --muted:#cbbf99;
+  --color-card:#fff7e0;
+  --color-dark:#0f0d1c;
+  --space-sm:clamp(12px, 1.5vw, 20px);
+  --radius-sm:8px;
+  --radius-md:12px;
+  --radius-lg:16px;
+}


### PR DESCRIPTION
## Summary
- add `variables.css` for reusable colors, spacing, and radii
- refactor styles to use shared variables
- ensure variable sheet is imported before other modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899c99d42488324a20be88001c8a9a3