### PR TITLE
style: expand single-line CSS declarations

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
     <div id="site-header"></div>
 
       <main>
-        <section class="layout cards">
+        <section class="layout cards u-grid u-items-start">
 
           <!-- Vollbreit: Text links, Bild rechts (nahtlos aneinander) -->
-          <div class="media-row">
+          <div class="media-row u-grid u-items-center">
             <div class="panel text">
               <h3>Get to know us</h3>
               <p>Erfahre mehr über unser Team und unsere Mission.</p>
@@ -53,7 +53,7 @@
           </figure>
 
           <!-- Vollbreit: Bild links, Text rechts -->
-          <div class="media-row reverse">
+          <div class="media-row reverse u-grid u-items-center">
             <div class="panel image">
               <img src="/public/images/merch.jpg" alt="Merch Foto">
             </div>

--- a/pages/home/index.html
+++ b/pages/home/index.html
@@ -22,15 +22,15 @@
   <div id="site-header"></div>
 
   <section class="section-grid container">
-    <div class="grid">
+    <div class="grid u-grid">
       <!-- 1) links oben -->
-      <a class="card cream round shadow" href="/pages/team/">
+      <a class="card card--cream round shadow" href="/pages/team/">
         <h1 class="h1">Get to know us</h1>
         <div class="kicker">(Text „Team“)</div>
       </a>
 
       <!-- 2) rechts oben -->
-      <a class="card ink round shadow" href="/pages/team/">
+      <a class="card card--ink card--center round shadow" href="/pages/team/">
         <div>
           <div class="h2">Teamfoto</div>
         </div>
@@ -38,13 +38,13 @@
 
       <!-- 3) links mitte -->
       <a class="round shadow" href="/pages/lore-and-fate/" style="display:block">
-        <div class="card ink round" style="border-bottom-left-radius:0;border-bottom-right-radius:0">
+        <div class="card card--ink card--center round" style="border-bottom-left-radius:0;border-bottom-right-radius:0">
           <div>
             <div class="h2">Lore &amp; Fate</div>
             <div>Bild</div>
           </div>
         </div>
-        <div class="card cream" style="border-top-left-radius:0;border-top-right-radius:0">
+        <div class="card card--cream" style="border-top-left-radius:0;border-top-right-radius:0">
           <div class="h2">Lore &amp; Fate</div>
           <div class="kicker">(Text „Lore &amp; Fate“)</div>
         </div>
@@ -52,25 +52,25 @@
 
       <!-- 4) rechts mitte -->
       <a class="round shadow" href="/pages/toolkit/" style="display:block">
-        <div class="card ink round" style="border-bottom-left-radius:0;border-bottom-right-radius:0">
+        <div class="card card--ink card--center round" style="border-bottom-left-radius:0;border-bottom-right-radius:0">
           <div>
             <div class="h2">Toolkit</div>
             <div>Bild</div>
           </div>
         </div>
-        <div class="card cream" style="border-top-left-radius:0;border-top-right-radius:0">
+        <div class="card card--cream" style="border-top-left-radius:0;border-top-right-radius:0">
           <div class="h2">Toolkit</div>
           <div class="kicker">(Text „Toolkit“)</div>
         </div>
       </a>
 
       <!-- 5) links unten -->
-      <a class="card ink round shadow" href="/pages/merch/">
+      <a class="card card--ink card--center round shadow" href="/pages/merch/">
         <div class="h2">Merch Foto</div>
       </a>
 
       <!-- 6) rechts unten -->
-      <a class="card cream round shadow" href="/pages/merch/">
+      <a class="card card--cream round shadow" href="/pages/merch/">
         <div class="h1">Merch</div>
         <div class="kicker">(Text „Merch“)</div>
       </a>

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -1,5 +1,5 @@
 <header class="site-header" role="navigation" aria-label="Main">
-  <div class="container">
+  <div class="container u-items-center">
     <div class="logo"><a class="logo-link" href="/"><img src="/images/brand/Logo_big.png" alt="Eclipsion logo" /></a></div>
     <nav class="main-nav">
       <a href="/">Home</a>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -10,6 +10,8 @@
   --ink:#1b1633;
   --text:#f7f3e8;
   --muted:#cbbf99;
+  --card-cream-text:#1a1408;
+  --card-ink-text:#f1efe9;
 }
 
 *{box-sizing:border-box}
@@ -26,3 +28,7 @@ a:focus-visible{outline:2px solid var(--bg-top-4)}
 .container{max-width:1200px;margin:0 auto;padding:0 clamp(16px,4vw,48px)}
 .shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
 .round{border-radius:16px}
+
+.u-grid{display:grid}
+.u-items-center{align-items:center}
+.u-items-start{align-items:start}

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,10 +1,8 @@
 /* Container: 2-Spalten-Grid für die Kacheln */
 .layout.cards{
   --gap: clamp(16px, 3vw, 28px);
-  display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--gap);
-  align-items: start;
   grid-auto-flow: dense;
   max-width: 1200px;
   margin: 0 auto;
@@ -14,10 +12,8 @@
 /* Vollbreite-Reihe: Text & Bild sind zwei separaten Felder ohne sichtbare Fuge */
 .cards .media-row{
   grid-column: 1 / -1;
-  display: grid;
   grid-template-columns: 1fr 1fr; /* Text | Bild */
   gap: 0;                         /* kein Zwischenraum */
-  align-items: center;            /* Mittelpunkte ausrichten */
   position: relative;             /* für gemeinsamen Shadow */
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -13,7 +13,8 @@
 }
 
 .site-header .container{
-  display:flex; align-items:center; justify-content:space-between;
+  display:flex;
+  justify-content:space-between;
 }
 
 /* Sobald der Header oben "klebt" (Klasse via JS) etwas deckender + Schatten */
@@ -24,38 +25,82 @@
 }
 
 /* Kleine Feinschliffe */
-.logo a { color: inherit; text-decoration: none; }
-.logo a:hover { filter: brightness(1.08); }
-.logo{font-weight:700; letter-spacing:.06em}
-.logo img{display:block;height:clamp(48px,8vw,96px);width:auto;}
+.logo a {
+  color: inherit;
+  text-decoration: none;
+}
+.logo a:hover {
+  filter: brightness(1.08);
+}
+.logo{
+  font-weight:700;
+  letter-spacing:.06em;
+}
+.logo img{
+  display:block;
+  height:clamp(48px,8vw,96px);
+  width:auto;
+}
 .main-nav a{
   margin-left:24px;
   font-size: 22px;
 }
-.main-nav a:hover{text-decoration:underline}
+.main-nav a:hover{
+  text-decoration:underline;
+}
 
 
 /* Content Grid */
-.section-grid{margin-top:0; position:relative; z-index:20}
-.grid{
-  display:grid; grid-template-columns:1.25fr 1fr; gap:32px;
+.section-grid{
+  margin-top:0;
+  position:relative;
+  z-index:20;
 }
-@media (max-width: var(--bp-tablet)){ .grid{grid-template-columns:1fr 1fr}}
-@media (max-width: var(--bp-mobile)){ .grid{grid-template-columns:1fr; gap:24px} }
+.grid{
+  grid-template-columns:1.25fr 1fr;
+  gap:32px;
+}
 
-.card{padding:24px 28px}
-.card.cream{background:var(--card-cream); color:#1a1408}
-.card.ink{background:var(--ink); color:#f1efe9; display:flex; align-items:center; justify-content:center; text-align:center}
-.card:hover{transform:translateY(-2px); box-shadow:0 16px 40px rgba(0,0,0,.4)}
-.card{transition:.2s transform,.2s box-shadow}
+.card{
+  padding:24px 28px;
+  background:var(--card-bg);
+  color:var(--card-text);
+  transition:.2s transform,.2s box-shadow;
+}
+.card--cream{
+  --card-bg:var(--card-cream);
+  --card-text:var(--card-cream-text);
+}
+.card--ink{
+  --card-bg:var(--ink);
+  --card-text:var(--card-ink-text);
+}
+.card--center{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+}
+.card:hover{
+  transform:translateY(-2px);
+  box-shadow:0 16px 40px rgba(0,0,0,.4);
+}
 
 /* Footer */
 .site-footer{
-  margin-top:64px; padding:24px; text-align:center;
-  background:#0d0a12; border-top:1px solid rgba(255,255,255,.06);
+  margin-top:64px;
+  padding:24px;
+  text-align:center;
+  background:#0d0a12;
+  border-top:1px solid rgba(255,255,255,.06);
 }
-.site-footer a{opacity:.9}
-.site-footer a:hover{opacity:1; text-decoration:underline}
+.site-footer a{
+  opacity:.9;
+}
+.site-footer a:hover{
+  opacity:1;
+  text-decoration:underline;
+}
 
 /* === Firewatch-Style Hero === */
 .hero{
@@ -66,7 +111,11 @@
 }
 .hero .layer,
 .hero .sun,
-.hero .fog { position:absolute; inset:0; pointer-events:none; }
+.hero .fog{
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+}
 
 /* Himmel mit warmem Verlauf + leichte Sättigung */
 .hero .sky{
@@ -84,8 +133,10 @@
 /* Sonne – radialer Glow */
 .hero .sun{
   z-index: 2;
-  width: 220px; height: 220px;
-  left: 50%; top: 22%;
+  width: 220px;
+  height: 220px;
+  left: 50%;
+  top: 22%;
   transform: translate(-50%, -50%);
   border-radius:50%;
   background:
@@ -129,14 +180,9 @@
 }
 
 /* Performance-Hinweise */
-.hero .layer{ will-change: transform; transform-origin: center bottom; }
-@media (max-width: var(--bp-mobile)){
-  .hero{ min-height: 56vh; }
-  .hero .sun{ width: 180px; height: 180px; top: 24%; }
-}
-@media (prefers-reduced-motion: reduce){
-  .hero .layer, .hero .sun{ transform: none !important; }
-  .hero .fog{ opacity: .25; }
+.hero .layer{
+  will-change: transform;
+  transform-origin: center bottom;
 }
 
 :root{
@@ -149,7 +195,6 @@
 }
 
 .landing-container{
-  display: grid;
   gap: var(--landing-row-gap);
   max-width: 1200px;
   margin: 0 auto;
@@ -177,7 +222,6 @@
   background: #0f0d1c;
   border: 4px solid var(--landing-ink);
   block-size: var(--landing-image-h);
-  display: grid;
 }
 .landing-card__image img{
   inline-size: 100%;
@@ -192,7 +236,6 @@
   block-size: calc(var(--landing-image-h) * 0.75);
   align-self: center;
   padding: clamp(18px, 2vw, 28px);
-  display: grid;
   align-content: center;
   gap: .5rem;
 }
@@ -203,14 +246,50 @@
 }
 
 .landing-stack{
-  display: grid;
   gap: clamp(12px, 1.5vw, 20px);
   flex: 1 1 0;
   min-inline-size: 0;
 }
 
+/* Media Queries */
+
+@media (max-width: var(--bp-tablet)){
+  .grid{
+    grid-template-columns:1fr 1fr;
+  }
+}
+
+@media (max-width: var(--bp-mobile)){
+  .grid{
+    grid-template-columns:1fr;
+    gap:24px;
+  }
+  .hero{
+    min-height: 56vh;
+  }
+  .hero .sun{
+    width: 180px;
+    height: 180px;
+    top: 24%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .hero .layer,
+  .hero .sun{
+    transform: none !important;
+  }
+  .hero .fog{
+    opacity: .25;
+  }
+}
+
 @media (max-width: 900px){
-  .landing-row{ flex-direction: column; }
+  .landing-row{
+    flex-direction: column;
+  }
   .landing-card__image,
-  .landing-card__text{ block-size: auto; }
+  .landing-card__text{
+    block-size: auto;
+  }
 }


### PR DESCRIPTION
## Summary
- break multi-property CSS rule sets into one property per line for readability
- centralize media queries into a dedicated section in `layout.css`
- extract card variant colors into CSS variables and add utility classes for variants and centering
- factor out repeated grid and alignment properties into `u-grid` and `u-items-*` utility classes and update markup

## Testing
- `npm test`
- `npm run lint:css` *(fails: Unknown rule indentation, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6899cd0555e083248729d3a477f21a77